### PR TITLE
Fix test execution through mvn test goal

### DIFF
--- a/src/test/java/br/com/squadjoaquina/errorlogger/integration/EndpointTest.java
+++ b/src/test/java/br/com/squadjoaquina/errorlogger/integration/EndpointTest.java
@@ -17,7 +17,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = {ErrorLoggerApplication.class})
-@TestPropertySource(locations = "classpath:test.properties")
+@TestPropertySource(locations = "classpath:application.properties")
 @WebAppConfiguration
 @NoArgsConstructor
 @Sql({"classpath:test_data.sql"})

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url= jdbc:h2:mem:test
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+jwt.secret=codenation
+jwt.expiration=2592000

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,5 +1,0 @@
-spring.datasource.url= jdbc:h2:mem:test
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=test
-spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Anteriormente era possível executar os testes unitários através da IDE intellij, mas não através do goal mvn:test. Esse commit corrige esse problema fazendo com que o maven carregue o arquivo de propriedades de teste de forma correta.