### PR TITLE
Hide Auth controller from swagger documentation

### DIFF
--- a/src/main/java/br/com/squadjoaquina/errorlogger/controller/AuthController.java
+++ b/src/main/java/br/com/squadjoaquina/errorlogger/controller/AuthController.java
@@ -1,32 +1,13 @@
 package br.com.squadjoaquina.errorlogger.controller;
 
-import br.com.squadjoaquina.errorlogger.dto.UserDTO;
-import br.com.squadjoaquina.errorlogger.security.JWTUtil;
-import br.com.squadjoaquina.errorlogger.service.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpServletResponse;
 
-@RestController
-@RequestMapping(value = "/auth")
-public class AuthController {
+public interface AuthController {
 
-    @Autowired
-    private JWTUtil jwtUtil;
-
-
-    @RequestMapping(value = "/refresh_token", method = RequestMethod.POST)
-    public ResponseEntity<Void> refreshToken(HttpServletResponse response) {
-        UserDTO user = UserService.authenticated();
-        String token = jwtUtil.generateToken(user.getUsername());
-        response.addHeader("Authorization", "Bearer " + token);
-        response.addHeader("access-control-expose-headers", "Authorization");
-        return ResponseEntity.noContent().build();
-    }
-
+    @ApiIgnore
+    ResponseEntity<Void> refreshToken(HttpServletResponse response);
 
 }

--- a/src/main/java/br/com/squadjoaquina/errorlogger/controller/impl/AuthControllerImpl.java
+++ b/src/main/java/br/com/squadjoaquina/errorlogger/controller/impl/AuthControllerImpl.java
@@ -1,0 +1,34 @@
+package br.com.squadjoaquina.errorlogger.controller.impl;
+
+import br.com.squadjoaquina.errorlogger.controller.AuthController;
+import br.com.squadjoaquina.errorlogger.dto.UserDTO;
+import br.com.squadjoaquina.errorlogger.security.JWTUtil;
+import br.com.squadjoaquina.errorlogger.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+
+@RestController
+@RequestMapping(value = "/auth")
+public class AuthControllerImpl implements AuthController {
+
+    @Autowired
+    private JWTUtil jwtUtil;
+
+
+    @RequestMapping(value = "/refresh_token", method = RequestMethod.POST)
+    public ResponseEntity<Void> refreshToken(HttpServletResponse response) {
+        UserDTO user = UserService.authenticated();
+        String token = jwtUtil.generateToken(user.getUsername());
+        response.addHeader("Authorization", "Bearer " + token);
+        response.addHeader("access-control-expose-headers", "Authorization");
+        return ResponseEntity.noContent()
+                             .build();
+    }
+
+
+}


### PR DESCRIPTION
Faz com que o auth controller e seu método para refresh de token não apareça na documentação swagger.

Como nenhum dos outros métodos relativos a autenticação são exibidos na documentação, achei que o método de refresh também não deveria ser.