### PR TITLE
Omit email password from application.properties. Add email config to …

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,7 @@ jwt.expiration=2592000
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=errorloggersquad3@gmail.com
-spring.mail.password=czwwznlqbysodjjq
+spring.mail.password=
+#Set the email password locally.
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -6,3 +6,12 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 
 jwt.secret=codenation
 jwt.expiration=2592000
+
+# Gmail configuration on Spring Mail
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=errorloggersquad3@gmail.com
+spring.mail.password=
+#Set the email password locally.
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true


### PR DESCRIPTION
Omite a senha do e-mail do aplication.properties de produção e adiciona a configuração de e-mail para o application.properties usado pelos testes.

A senha do email deve ser definida localmente nos applications.properties de desenvolvimento.

@FelipeCooper precisamos de variáveis de ambiente do docker para configurar a parte do e-mail utilizado para enviar e-mails de troca de senhas.