### PR TITLE
Remove ASCII doctor plugin from pom.xml to prevent errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,31 +99,6 @@
 <build>
 <plugins>
     <plugin>
-        <groupId>org.asciidoctor</groupId>
-        <artifactId>asciidoctor-maven-plugin</artifactId>
-        <version>1.5.8</version>
-        <executions>
-            <execution>
-                <id>generate-docs</id>
-                <phase>prepare-package</phase>
-                <goals>
-                    <goal>process-asciidoc</goal>
-                </goals>
-                <configuration>
-                    <backend>html</backend>
-                    <doctype>book</doctype>
-                </configuration>
-            </execution>
-        </executions>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.restdocs</groupId>
-                <artifactId>spring-restdocs-asciidoctor</artifactId>
-                <version>1.2.0.RC1</version>
-            </dependency>
-        </dependencies>
-    </plugin>
-    <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
     </plugin>


### PR DESCRIPTION
Remove o plugin ASCII doctor do maven, que vinha gerando alguns bugs.